### PR TITLE
Ensure PIL images closed

### DIFF
--- a/main.py
+++ b/main.py
@@ -1022,19 +1022,20 @@ if __name__ == "__main__":
                                 completion_text
                             )
                             if parsed_click:
-                                pil_img = PILImage.open(log_data["img_path"])
-                                plot_data = [
-                                    {
-                                        "name": "VLM Click",
-                                        "center_x": parsed_click[0],
-                                        "center_y": parsed_click[1],
-                                        "is_truth": False,
-                                    }
-                                ]
-                                img_w_click = GUIGenerator.plot_predictions(
-                                    pil_img, plot_data, pred_color="red"
-                                )
-                                img_w_click.save(vis_train_img_path)
+                                with PILImage.open(log_data["img_path"]) as pil_img:
+                                    plot_data = [
+                                        {
+                                            "name": "VLM Click",
+                                            "center_x": parsed_click[0],
+                                            "center_y": parsed_click[1],
+                                            "is_truth": False,
+                                        }
+                                    ]
+                                    img_w_click = GUIGenerator.plot_predictions(
+                                        pil_img, plot_data, pred_color="red"
+                                    )
+                                    img_w_click.save(vis_train_img_path)
+                                    img_w_click.close()
                                 img_path_for_pdf_entry = vis_train_img_path
                             else:
                                 img_path_for_pdf_entry = log_data[

--- a/src/simple_grpo/utils/plotter.py
+++ b/src/simple_grpo/utils/plotter.py
@@ -19,21 +19,23 @@ def plot_captcha_evaluation(
     verbose: bool = False,
 ) -> bool:
     """Just plots X's where the model clicked."""
-    img = PILImage.open(base_image_path).convert("RGB")
-    draw = ImageDraw.Draw(img)
+    with PILImage.open(base_image_path) as img:
+        img = img.convert("RGB")
+        draw = ImageDraw.Draw(img)
 
-    # Draw an X for each click
-    for x, y in predicted_clicks:
-        # Draw X with fixed size
-        size = 10
-        draw.line(
-            [(x - size, y - size), (x + size, y + size)], fill=(255, 0, 0), width=3
-        )
-        draw.line(
-            [(x + size, y - size), (x - size, y + size)], fill=(255, 0, 0), width=3
-        )
+        # Draw an X for each click
+        for x, y in predicted_clicks:
+            # Draw X with fixed size
+            size = 10
+            draw.line(
+                [(x - size, y - size), (x + size, y + size)], fill=(255, 0, 0), width=3
+            )
+            draw.line(
+                [(x + size, y - size), (x - size, y + size)], fill=(255, 0, 0), width=3
+            )
 
-    img.save(output_path)
+        img.save(output_path)
+        img.close()
     return True
 
 

--- a/src/simple_grpo/utils/process.py
+++ b/src/simple_grpo/utils/process.py
@@ -108,18 +108,19 @@ def _process_single_completion_for_eval(
                         completion_text
                     )  # Protected access, but used in main.py
                     if parsed_click:
-                        pil_img = PILImage.open(original_image_path)
-                        plot_data = [
-                            {
-                                "name": "VLM Click",
-                                "center_x": parsed_click[0],
-                                "center_y": parsed_click[1],
-                                "is_truth": False,
-                            }
-                        ]
-                        # GUIGenerator.plot_predictions returns a PIL Image
-                        img_w_click = gui_plotter(pil_img, plot_data, pred_color="red")
-                        img_w_click.save(vis_image_path_for_pdf)
+                        with PILImage.open(original_image_path) as pil_img:
+                            plot_data = [
+                                {
+                                    "name": "VLM Click",
+                                    "center_x": parsed_click[0],
+                                    "center_y": parsed_click[1],
+                                    "is_truth": False,
+                                }
+                            ]
+                            # GUIGenerator.plot_predictions returns a PIL Image
+                            img_w_click = gui_plotter(pil_img, plot_data, pred_color="red")
+                            img_w_click.save(vis_image_path_for_pdf)
+                            img_w_click.close()
                         img_path_for_pdf_entry = vis_image_path_for_pdf
                     else:
                         # If click not parsed, use original image for PDF (or None if vis_image_path_for_pdf was for specific click)

--- a/src/simple_grpo/utils/reports.py
+++ b/src/simple_grpo/utils/reports.py
@@ -86,8 +86,8 @@ def _add_example_header_to_pdf(
     # Display image if path is valid
     if os.path.exists(image_path):
         try:
-            img = PILImage.open(image_path)
-            img_width, img_height = img.size
+            with PILImage.open(image_path) as img:
+                img_width, img_height = img.size
             aspect = img_height / float(img_width)
             display_width = 2.5 * inch  # Max width for the image in PDF
             display_height = display_width * aspect
@@ -122,8 +122,8 @@ def _add_example_header_to_pdf(
                                 styles["BodyText"],
                             )
                         )
-                        sol_img = PILImage.open(solution_image_path)
-                        sol_img_width, sol_img_height = sol_img.size
+                        with PILImage.open(solution_image_path) as sol_img:
+                            sol_img_width, sol_img_height = sol_img.size
                         sol_aspect = sol_img_height / float(sol_img_width)
                         sol_display_width = 2.5 * inch
                         sol_display_height = sol_display_width * sol_aspect
@@ -214,8 +214,8 @@ def _add_completion_to_pdf(
     # Display image for this completion (e.g., with click for GUI)
     if image_path_for_completion_pdf and os.path.exists(image_path_for_completion_pdf):
         try:
-            img = PILImage.open(image_path_for_completion_pdf)
-            img_width, img_height = img.size
+            with PILImage.open(image_path_for_completion_pdf) as img:
+                img_width, img_height = img.size
             aspect = img_height / float(img_width)
             display_width = 2.0 * inch  # Slightly smaller for completion image
             display_height = display_width * aspect
@@ -434,18 +434,19 @@ def _process_single_completion_for_eval(
                         completion_text
                     )  # Protected access, but used in main.py
                     if parsed_click:
-                        pil_img = PILImage.open(original_image_path)
-                        plot_data = [
-                            {
-                                "name": "VLM Click",
-                                "center_x": parsed_click[0],
-                                "center_y": parsed_click[1],
-                                "is_truth": False,
-                            }
-                        ]
-                        # GUIGenerator.plot_predictions returns a PIL Image
-                        img_w_click = gui_plotter(pil_img, plot_data, pred_color="red")
-                        img_w_click.save(vis_image_path_for_pdf)
+                        with PILImage.open(original_image_path) as pil_img:
+                            plot_data = [
+                                {
+                                    "name": "VLM Click",
+                                    "center_x": parsed_click[0],
+                                    "center_y": parsed_click[1],
+                                    "is_truth": False,
+                                }
+                            ]
+                            # GUIGenerator.plot_predictions returns a PIL Image
+                            img_w_click = gui_plotter(pil_img, plot_data, pred_color="red")
+                            img_w_click.save(vis_image_path_for_pdf)
+                            img_w_click.close()
                         img_path_for_pdf_entry = vis_image_path_for_pdf
                     else:
                         # If click not parsed, use original image for PDF (or None if vis_image_path_for_pdf was for specific click)
@@ -631,8 +632,8 @@ def _add_training_completion_to_pdf(
     # Display visualized image (e.g., with click for GUI)
     if image_path_for_completion_pdf and os.path.exists(image_path_for_completion_pdf):
         try:
-            img = PILImage.open(image_path_for_completion_pdf)
-            img_width, img_height = img.size
+            with PILImage.open(image_path_for_completion_pdf) as img:
+                img_width, img_height = img.size
             aspect = img_height / float(img_width)
             display_width = 2.0 * inch
             display_height = display_width * aspect


### PR DESCRIPTION
## Summary
- avoid memory leaks by using context managers for PILImage
- close intermediate images after saving

## Testing
- `python -m compileall -q src main.py`